### PR TITLE
添加功放唱片机

### DIFF
--- a/src/main/java/com/github/tartaricacid/netmusic/block/BlockAmplifiedMusicPlayer.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/block/BlockAmplifiedMusicPlayer.java
@@ -1,0 +1,24 @@
+package com.github.tartaricacid.netmusic.block;
+
+import com.github.tartaricacid.netmusic.tileentity.TileEntityAmplifiedMusicPlayer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+
+import javax.annotation.Nullable;
+
+public class BlockAmplifiedMusicPlayer extends BlockMusicPlayer {
+    @Override
+    public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
+        return new TileEntityAmplifiedMusicPlayer(pos, state);
+    }
+
+    @Nullable
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState blockState, BlockEntityType<T> entityType) {
+        return !level.isClientSide ? createTickerHelper(entityType, TileEntityAmplifiedMusicPlayer.TYPE, TileEntityAmplifiedMusicPlayer::tick) : null;
+    }
+}

--- a/src/main/java/com/github/tartaricacid/netmusic/block/BlockMusicPlayer.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/block/BlockMusicPlayer.java
@@ -84,32 +84,33 @@ public class BlockMusicPlayer extends HorizontalDirectionalBlock implements Enti
 
     @Override
     public void neighborChanged(BlockState state, Level level, BlockPos blockPos, Block block, BlockPos fromPos, boolean isMoving) {
-        playerMusic(level, blockPos, level.hasNeighborSignal(blockPos));
+        playerMusic(level, blockPos, level.getBestNeighborSignal(blockPos));
     }
 
-    private static void playerMusic(Level level, BlockPos blockPos, boolean signal) {
+    private static void playerMusic(Level level, BlockPos blockPos, int signal) {
         BlockEntity blockEntity = level.getBlockEntity(blockPos);
         if (blockEntity instanceof TileEntityMusicPlayer player) {
-            if (signal != player.hasSignal()) {
-                if (signal) {
+            boolean hasSignal = signal != 0;
+            if (hasSignal != player.hasSignal()) {
+                if (hasSignal) {
                     if (player.isPlay()) {
                         player.setPlay(false);
-                        player.setSignal(signal);
+                        player.setSignal(true);
                         player.markDirty();
                         return;
                     }
                     ItemStack stackInSlot = player.getPlayerInv().getStackInSlot(0);
                     if (stackInSlot.isEmpty()) {
-                        player.setSignal(signal);
+                        player.setSignal(true);
                         player.markDirty();
                         return;
                     }
                     ItemMusicCD.SongInfo songInfo = ItemMusicCD.getSongInfo(stackInSlot);
                     if (songInfo != null) {
-                        player.setPlayToClient(songInfo);
+                        player.setPlayToClient(songInfo, signal);
                     }
                 }
-                player.setSignal(signal);
+                player.setSignal(hasSignal);
                 player.markDirty();
             }
         }

--- a/src/main/java/com/github/tartaricacid/netmusic/block/BlockMusicPlayer.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/block/BlockMusicPlayer.java
@@ -24,6 +24,8 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
@@ -40,9 +42,18 @@ import java.util.function.Consumer;
 public class BlockMusicPlayer extends HorizontalDirectionalBlock implements EntityBlock {
     protected static final VoxelShape BLOCK_AABB = Block.box(2, 0, 2, 14, 6, 14);
 
+    public static final BooleanProperty HAS_RECORD = BlockStateProperties.HAS_RECORD;
+    public static final BooleanProperty POWERED = BlockStateProperties.POWERED;
+    public static final BooleanProperty ENABLED = BlockStateProperties.ENABLED;
+
     public BlockMusicPlayer() {
         super(BlockBehaviour.Properties.of().sound(SoundType.WOOD).strength(0.5f).noOcclusion());
-        this.registerDefaultState(this.stateDefinition.any().setValue(FACING, Direction.SOUTH));
+        this.registerDefaultState(this.stateDefinition.any()
+                .setValue(FACING, Direction.SOUTH)
+                .setValue(HAS_RECORD, false)
+                .setValue(POWERED, false)
+                .setValue(ENABLED, false)
+        );
     }
 
     @Nullable
@@ -54,6 +65,9 @@ public class BlockMusicPlayer extends HorizontalDirectionalBlock implements Enti
     @Override
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
         builder.add(FACING);
+        builder.add(HAS_RECORD);
+        builder.add(POWERED);
+        builder.add(ENABLED);
     }
 
     @Nullable
@@ -158,6 +172,9 @@ public class BlockMusicPlayer extends HorizontalDirectionalBlock implements Enti
 
     @Override
     public void onRemove(BlockState state, Level worldIn, BlockPos pos, BlockState newState, boolean isMoving) {
+        if (state.is(newState.getBlock())) {
+            return;
+        }
         BlockEntity te = worldIn.getBlockEntity(pos);
         if (te instanceof TileEntityMusicPlayer) {
             TileEntityMusicPlayer musicPlayer = (TileEntityMusicPlayer) te;

--- a/src/main/java/com/github/tartaricacid/netmusic/client/audio/NetMusicSound.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/client/audio/NetMusicSound.java
@@ -27,13 +27,17 @@ public class NetMusicSound extends AbstractTickableSoundInstance {
     private int tick;
 
     public NetMusicSound(BlockPos pos, URL songUrl, int timeSecond) {
+        this(pos, songUrl, timeSecond, 4.0f);
+    }
+
+    public NetMusicSound(BlockPos pos, URL songUrl, int timeSecond, float volume) {
         super(InitSounds.NET_MUSIC.get(), SoundSource.RECORDS, SoundInstance.createUnseededRandom());
         this.songUrl = songUrl;
         this.x = pos.getX() + 0.5f;
         this.y = pos.getY() + 0.5f;
         this.z = pos.getZ() + 0.5f;
         this.tickTimes = timeSecond * 20;
-        this.volume = 4.0f;
+        this.volume = volume;
         this.tick = 0;
         this.pos = pos;
     }

--- a/src/main/java/com/github/tartaricacid/netmusic/client/init/InitModel.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/client/init/InitModel.java
@@ -3,6 +3,7 @@ package com.github.tartaricacid.netmusic.client.init;
 
 import com.github.tartaricacid.netmusic.client.model.ModelMusicPlayer;
 import com.github.tartaricacid.netmusic.client.renderer.MusicPlayerRenderer;
+import com.github.tartaricacid.netmusic.tileentity.TileEntityAmplifiedMusicPlayer;
 import com.github.tartaricacid.netmusic.tileentity.TileEntityMusicPlayer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderers;
 import net.minecraftforge.api.distmarker.Dist;
@@ -16,6 +17,7 @@ public class InitModel {
     @SubscribeEvent
     public static void clientSetup(FMLClientSetupEvent evt) {
         BlockEntityRenderers.register(TileEntityMusicPlayer.TYPE, MusicPlayerRenderer::new);
+        BlockEntityRenderers.register(TileEntityAmplifiedMusicPlayer.TYPE, MusicPlayerRenderer::new);
     }
 
     @SubscribeEvent

--- a/src/main/java/com/github/tartaricacid/netmusic/init/InitBlocks.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/init/InitBlocks.java
@@ -1,9 +1,11 @@
 package com.github.tartaricacid.netmusic.init;
 
 import com.github.tartaricacid.netmusic.NetMusic;
+import com.github.tartaricacid.netmusic.block.BlockAmplifiedMusicPlayer;
 import com.github.tartaricacid.netmusic.block.BlockCDBurner;
 import com.github.tartaricacid.netmusic.block.BlockComputer;
 import com.github.tartaricacid.netmusic.block.BlockMusicPlayer;
+import com.github.tartaricacid.netmusic.tileentity.TileEntityAmplifiedMusicPlayer;
 import com.github.tartaricacid.netmusic.tileentity.TileEntityMusicPlayer;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -16,8 +18,10 @@ public class InitBlocks {
     public static final DeferredRegister<BlockEntityType<?>> TILE_ENTITIES = DeferredRegister.create(ForgeRegistries.BLOCK_ENTITY_TYPES, NetMusic.MOD_ID);
 
     public static RegistryObject<Block> MUSIC_PLAYER = BLOCKS.register("music_player", BlockMusicPlayer::new);
+    public static RegistryObject<Block> AMPLIFIED_MUSIC_PLAYER = BLOCKS.register("amplified_music_player", BlockAmplifiedMusicPlayer::new);
     public static RegistryObject<Block> CD_BURNER = BLOCKS.register("cd_burner", BlockCDBurner::new);
     public static RegistryObject<Block> COMPUTER = BLOCKS.register("computer", BlockComputer::new);
 
     public static RegistryObject<BlockEntityType<TileEntityMusicPlayer>> MUSIC_PLAYER_TE = TILE_ENTITIES.register("music_player", () -> TileEntityMusicPlayer.TYPE);
+    public static RegistryObject<BlockEntityType<TileEntityAmplifiedMusicPlayer>> AMPLIFIED_MUSIC_PLAYER_TE = TILE_ENTITIES.register("amplified_music_player", () -> TileEntityAmplifiedMusicPlayer.TYPE);
 }

--- a/src/main/java/com/github/tartaricacid/netmusic/init/InitItems.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/init/InitItems.java
@@ -3,6 +3,7 @@ package com.github.tartaricacid.netmusic.init;
 import com.github.tartaricacid.netmusic.NetMusic;
 import com.github.tartaricacid.netmusic.client.config.MusicListManage;
 import com.github.tartaricacid.netmusic.compat.tlm.init.CompatRegistry;
+import com.github.tartaricacid.netmusic.item.ItemAmplifiedMusicPlayer;
 import com.github.tartaricacid.netmusic.item.ItemMusicCD;
 import com.github.tartaricacid.netmusic.item.ItemMusicPlayer;
 import net.minecraft.core.registries.Registries;
@@ -21,6 +22,7 @@ public class InitItems {
 
     public static RegistryObject<Item> MUSIC_CD = ITEMS.register("music_cd", ItemMusicCD::new);
     public static RegistryObject<Item> MUSIC_PLAYER = ITEMS.register("music_player", ItemMusicPlayer::new);
+    public static RegistryObject<Item> AMPLIFIED_MUSIC_PLAYER = ITEMS.register("amplified_music_player", ItemAmplifiedMusicPlayer::new);
     public static RegistryObject<Item> CD_BURNER = ITEMS.register("cd_burner", () -> new BlockItem(InitBlocks.CD_BURNER.get(), new Item.Properties().stacksTo(1)));
     public static RegistryObject<Item> COMPUTER = ITEMS.register("computer", () -> new BlockItem(InitBlocks.COMPUTER.get(), new Item.Properties().stacksTo(1)));
     public static RegistryObject<Item> MUSIC_PLAYER_BACKPACK = ITEMS.register("music_player_backpack", () -> new Item(new Item.Properties().stacksTo(1)));
@@ -28,6 +30,7 @@ public class InitItems {
     public static RegistryObject<CreativeModeTab> NET_MUSIC_TAB = TABS.register("netmusic", () -> CreativeModeTab.builder().title(Component.translatable("itemGroup.netmusic"))
             .icon(() -> new ItemStack(InitBlocks.MUSIC_PLAYER.get())).displayItems((parameters, output) -> {
                         output.accept(new ItemStack(MUSIC_PLAYER.get()));
+                        output.accept(new ItemStack(AMPLIFIED_MUSIC_PLAYER.get()));
                         output.accept(new ItemStack(InitItems.CD_BURNER.get()));
                         output.accept(new ItemStack(InitItems.COMPUTER.get()));
                         CompatRegistry.initCreativeModeTab(output);

--- a/src/main/java/com/github/tartaricacid/netmusic/inventory/MusicPlayerInv.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/inventory/MusicPlayerInv.java
@@ -1,7 +1,6 @@
 package com.github.tartaricacid.netmusic.inventory;
 
 import com.github.tartaricacid.netmusic.init.InitItems;
-import com.github.tartaricacid.netmusic.item.ItemMusicCD;
 import com.github.tartaricacid.netmusic.tileentity.TileEntityMusicPlayer;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.ItemStackHandler;
@@ -30,7 +29,9 @@ public class MusicPlayerInv extends ItemStackHandler {
     @Override
     protected void onContentsChanged(int slot) {
         ItemStack stackInSlot = getStackInSlot(slot);
-        if (stackInSlot.isEmpty()) {
+        boolean isEmpty = stackInSlot.isEmpty();
+        te.setHasRecord(!isEmpty);
+        if (isEmpty) {
             te.setPlay(false);
             te.setCurrentTime(0);
         }

--- a/src/main/java/com/github/tartaricacid/netmusic/item/ItemAmplifiedMusicPlayer.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/item/ItemAmplifiedMusicPlayer.java
@@ -1,0 +1,27 @@
+package com.github.tartaricacid.netmusic.item;
+
+import com.github.tartaricacid.netmusic.client.renderer.MusicPlayerItemRenderer;
+import com.github.tartaricacid.netmusic.init.InitBlocks;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
+import net.minecraft.world.item.BlockItem;
+import net.minecraftforge.client.extensions.common.IClientItemExtensions;
+
+import java.util.function.Consumer;
+
+public class ItemAmplifiedMusicPlayer extends BlockItem {
+    public ItemAmplifiedMusicPlayer() {
+        super(InitBlocks.AMPLIFIED_MUSIC_PLAYER.get(), (new Properties()));
+    }
+
+    @Override
+    public void initializeClient(Consumer<IClientItemExtensions> consumer) {
+        consumer.accept(new IClientItemExtensions() {
+            @Override
+            public BlockEntityWithoutLevelRenderer getCustomRenderer() {
+                Minecraft minecraft = Minecraft.getInstance();
+                return new MusicPlayerItemRenderer(minecraft.getBlockEntityRenderDispatcher(), minecraft.getEntityModels());
+            }
+        });
+    }
+}

--- a/src/main/java/com/github/tartaricacid/netmusic/network/NetworkHandler.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/network/NetworkHandler.java
@@ -35,11 +35,15 @@ public class NetworkHandler {
     }
 
     public static void sendToNearby(Level world, BlockPos pos, Object toSend) {
+        sendToNearby(world, pos, 96, toSend);
+    }
+
+    public static void sendToNearby(Level world, BlockPos pos, double maxDistance, Object toSend) {
         if (world instanceof ServerLevel) {
             ServerLevel ws = (ServerLevel) world;
 
             ws.getChunkSource().chunkMap.getPlayers(new ChunkPos(pos), false).stream()
-                    .filter(p -> p.distanceToSqr(pos.getX(), pos.getY(), pos.getZ()) < 96 * 96)
+                    .filter(p -> p.distanceToSqr(pos.getX(), pos.getY(), pos.getZ()) < maxDistance * maxDistance)
                     .forEach(p -> CHANNEL.send(PacketDistributor.PLAYER.with(() -> p), toSend));
         }
     }

--- a/src/main/java/com/github/tartaricacid/netmusic/network/NetworkHandler.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/network/NetworkHandler.java
@@ -19,7 +19,7 @@ import net.minecraftforge.network.simple.SimpleChannel;
 import java.util.Optional;
 
 public class NetworkHandler {
-    private static final String VERSION = "1.0.0";
+    private static final String VERSION = "1.0.1";
 
     public static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(new ResourceLocation(NetMusic.MOD_ID, "network"),
             () -> VERSION, it -> it.equals(VERSION), it -> it.equals(VERSION));

--- a/src/main/java/com/github/tartaricacid/netmusic/network/message/MusicToClientMessage.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/network/message/MusicToClientMessage.java
@@ -17,16 +17,22 @@ public class MusicToClientMessage {
     private final String url;
     private final int timeSecond;
     private final String songName;
+    private final float volume;
 
     public MusicToClientMessage(BlockPos pos, String url, int timeSecond, String songName) {
+        this(pos, url, timeSecond, songName, 4.0f);
+    }
+
+    public MusicToClientMessage(BlockPos pos, String url, int timeSecond, String songName, float volume) {
         this.pos = pos;
         this.url = url;
         this.timeSecond = timeSecond;
         this.songName = songName;
+        this.volume = volume;
     }
 
     public static MusicToClientMessage decode(FriendlyByteBuf buf) {
-        return new MusicToClientMessage(BlockPos.of(buf.readLong()), buf.readUtf(), buf.readInt(), buf.readUtf());
+        return new MusicToClientMessage(BlockPos.of(buf.readLong()), buf.readUtf(), buf.readInt(), buf.readUtf(), buf.readFloat());
     }
 
     public static void encode(MusicToClientMessage message, FriendlyByteBuf buf) {
@@ -34,6 +40,7 @@ public class MusicToClientMessage {
         buf.writeUtf(message.url);
         buf.writeInt(message.timeSecond);
         buf.writeUtf(message.songName);
+        buf.writeFloat(message.volume);
     }
 
     public static void handle(MusicToClientMessage message, Supplier<NetworkEvent.Context> contextSupplier) {
@@ -46,6 +53,6 @@ public class MusicToClientMessage {
 
     @OnlyIn(Dist.CLIENT)
     private static void onHandle(MusicToClientMessage message) {
-        MusicPlayManager.play(message.url, message.songName, url -> new NetMusicSound(message.pos, url, message.timeSecond));
+        MusicPlayManager.play(message.url, message.songName, url -> new NetMusicSound(message.pos, url, message.timeSecond, message.volume));
     }
 }

--- a/src/main/java/com/github/tartaricacid/netmusic/network/message/MusicToClientMessage.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/network/message/MusicToClientMessage.java
@@ -31,6 +31,10 @@ public class MusicToClientMessage {
         this.volume = volume;
     }
 
+    public float getVolume() {
+        return volume;
+    }
+
     public static MusicToClientMessage decode(FriendlyByteBuf buf) {
         return new MusicToClientMessage(BlockPos.of(buf.readLong()), buf.readUtf(), buf.readInt(), buf.readUtf(), buf.readFloat());
     }

--- a/src/main/java/com/github/tartaricacid/netmusic/tileentity/TileEntityAmplifiedMusicPlayer.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/tileentity/TileEntityAmplifiedMusicPlayer.java
@@ -1,0 +1,23 @@
+package com.github.tartaricacid.netmusic.tileentity;
+
+import com.github.tartaricacid.netmusic.init.InitBlocks;
+import com.github.tartaricacid.netmusic.item.ItemMusicCD;
+import com.github.tartaricacid.netmusic.network.message.MusicToClientMessage;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.NotNull;
+
+public class TileEntityAmplifiedMusicPlayer extends TileEntityMusicPlayer {
+    @SuppressWarnings("DataFlowIssue")
+    public static final BlockEntityType<TileEntityAmplifiedMusicPlayer> TYPE = BlockEntityType.Builder.of(TileEntityAmplifiedMusicPlayer::new, InitBlocks.AMPLIFIED_MUSIC_PLAYER.get()).build(null);
+
+    public TileEntityAmplifiedMusicPlayer(BlockPos blockPos, BlockState blockState) {
+        super(TYPE, blockPos, blockState);
+    }
+
+    @Override
+    protected @NotNull MusicToClientMessage createMusicToClientMessage(ItemMusicCD.SongInfo info, int signal) {
+        return new MusicToClientMessage(worldPosition, info.songUrl, info.songTime, info.songName, signal);
+    }
+}

--- a/src/main/java/com/github/tartaricacid/netmusic/tileentity/TileEntityMusicPlayer.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/tileentity/TileEntityMusicPlayer.java
@@ -125,7 +125,7 @@ public class TileEntityMusicPlayer extends BlockEntity {
         this.isPlay = true;
         if (level != null && !level.isClientSide) {
             MusicToClientMessage msg = createMusicToClientMessage(info, signal);
-            NetworkHandler.sendToNearby(level, worldPosition, msg);
+            NetworkHandler.sendToNearby(level, worldPosition, msg.getVolume() * 16 + 32, msg);
         }
     }
 

--- a/src/main/java/com/github/tartaricacid/netmusic/tileentity/TileEntityMusicPlayer.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/tileentity/TileEntityMusicPlayer.java
@@ -2,7 +2,6 @@ package com.github.tartaricacid.netmusic.tileentity;
 
 import com.github.tartaricacid.netmusic.block.BlockMusicPlayer;
 import com.github.tartaricacid.netmusic.init.InitBlocks;
-import com.github.tartaricacid.netmusic.init.InitItems;
 import com.github.tartaricacid.netmusic.inventory.MusicPlayerInv;
 import com.github.tartaricacid.netmusic.item.ItemMusicCD;
 import com.github.tartaricacid.netmusic.network.NetworkHandler;
@@ -13,25 +12,18 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
-import net.minecraft.world.Container;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.ChestBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.entity.TickingBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.items.IItemHandler;
-import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class TileEntityMusicPlayer extends BlockEntity {
@@ -46,8 +38,12 @@ public class TileEntityMusicPlayer extends BlockEntity {
     private int currentTime;
     private boolean hasSignal = false;
 
+    protected TileEntityMusicPlayer(BlockEntityType<?> type, BlockPos blockPos, BlockState blockState) {
+        super(type, blockPos, blockState);
+    }
+
     public TileEntityMusicPlayer(BlockPos blockPos, BlockState blockState) {
-        super(TYPE, blockPos, blockState);
+        this(TYPE, blockPos, blockState);
     }
 
     @Override
@@ -121,12 +117,21 @@ public class TileEntityMusicPlayer extends BlockEntity {
     }
 
     public void setPlayToClient(ItemMusicCD.SongInfo info) {
+        setPlayToClient(info, 15);
+    }
+
+    public void setPlayToClient(ItemMusicCD.SongInfo info, int signal) {
         this.setCurrentTime(info.songTime * 20 + 64);
         this.isPlay = true;
         if (level != null && !level.isClientSide) {
-            MusicToClientMessage msg = new MusicToClientMessage(worldPosition, info.songUrl, info.songTime, info.songName);
+            MusicToClientMessage msg = createMusicToClientMessage(info, signal);
             NetworkHandler.sendToNearby(level, worldPosition, msg);
         }
+    }
+
+    @NotNull
+    protected MusicToClientMessage createMusicToClientMessage(ItemMusicCD.SongInfo info, int signal) {
+        return new MusicToClientMessage(worldPosition, info.songUrl, info.songTime, info.songName);
     }
 
     public void markDirty() {

--- a/src/main/resources/assets/netmusic/blockstates/amplified_music_player.json
+++ b/src/main/resources/assets/netmusic/blockstates/amplified_music_player.json
@@ -1,0 +1,19 @@
+{
+	"variants": {
+		"facing=north": {
+			"model": "netmusic:block/amplified_music_player"
+		},
+		"facing=south": {
+			"model": "netmusic:block/amplified_music_player",
+			"y": 180
+		},
+		"facing=west": {
+			"model": "netmusic:block/amplified_music_player",
+			"y": 270
+		},
+		"facing=east": {
+			"model": "netmusic:block/amplified_music_player",
+			"y": 90
+		}
+	}
+}

--- a/src/main/resources/assets/netmusic/lang/en_us.json
+++ b/src/main/resources/assets/netmusic/lang/en_us.json
@@ -9,6 +9,7 @@
   "tooltips.netmusic.cd.empty": "Empty",
   "tooltips.netmusic.cd.read_only": "[Read Only]",
   "block.netmusic.music_player": "Music Player",
+  "block.netmusic.amplified_music_player": "Amplified Music Player",
   "block.netmusic.cd_burner": "CD Burner",
   "block.netmusic.cd_burner.desc": "Only NetEase Cloud Music links can be written (Only available in Chinese mainland)",
   "block.netmusic.computer": "Computer",

--- a/src/main/resources/assets/netmusic/lang/zh_cn.json
+++ b/src/main/resources/assets/netmusic/lang/zh_cn.json
@@ -1,4 +1,5 @@
 {
+  "block.netmusic.amplified_music_player": "功放唱片机",
   "block.netmusic.cd_burner": "唱片刻录机",
   "block.netmusic.cd_burner.desc": "只可以写入网易云音乐链接（仅可在中国大陆可用）",
   "block.netmusic.computer": "电脑",

--- a/src/main/resources/assets/netmusic/models/block/amplified_music_player.json
+++ b/src/main/resources/assets/netmusic/models/block/amplified_music_player.json
@@ -1,0 +1,3 @@
+{
+	"parent": "netmusic:block/music_player"
+}

--- a/src/main/resources/assets/netmusic/models/item/amplified_music_player.json
+++ b/src/main/resources/assets/netmusic/models/item/amplified_music_player.json
@@ -1,0 +1,3 @@
+{
+	"parent": "netmusic:item/music_player"
+}

--- a/src/main/resources/data/netmusic/loot_tables/blocks/amplified_music_player.json
+++ b/src/main/resources/data/netmusic/loot_tables/blocks/amplified_music_player.json
@@ -1,0 +1,19 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "netmusic:amplified_music_player"
+				}
+			],
+			"conditions": [
+				{
+					"condition": "minecraft:survives_explosion"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
## 动机
希望加入一个能在更大的、可控的范围播放音乐的唱片机。

## 内容
- 添加方块【功放唱片机】。
  - 含有唱片且未在播放的状态下，被红石信号激活时，根据输入的红石信号强度决定音乐的传播距离（传播距离 = 16 x 信号强度）。
  - 当玩家手动放入唱片时，唱片会直接被播放，传播距离为最大的 15 x 16 = 240。
  - 其余的行为与【唱片机】一致。

## 注释
目前该 PR 仅包含代码逻辑，模型暂时使用唱片机的模型替代。另外需要加入合成表。因此暂时将该 PR 标记为草稿。