### PR TITLE
优化音频流读取

### DIFF
--- a/src/main/java/com/github/tartaricacid/netmusic/client/audio/ChunkedAudioStream.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/client/audio/ChunkedAudioStream.java
@@ -13,7 +13,6 @@ import java.net.URLConnection;
  * @create : 2025/7/3
  */
 public class ChunkedAudioStream extends InputStream {
-    public static final int CHUNK_SIZE = 81920;
     private InputStream currentStream;
     private long currentStart;
     private final URL url;
@@ -32,8 +31,7 @@ public class ChunkedAudioStream extends InputStream {
     public int read() throws IOException {
         int b = currentStream.read();
         if (b == -1) {
-            // 到达当前流结尾，打开下一个片段
-            currentStart += CHUNK_SIZE;
+            // 尝试重新连接
             currentStream.close();
             currentStream = openChunk(currentStart);
             if (currentStream == null) {
@@ -41,6 +39,7 @@ public class ChunkedAudioStream extends InputStream {
             }
             b = currentStream.read();
         }
+        currentStart += b;
         return b;
     }
 
@@ -53,8 +52,7 @@ public class ChunkedAudioStream extends InputStream {
             conn = url.openConnection(proxy);
             conn.setConnectTimeout(3_000);
             conn.setReadTimeout(3_000);
-            conn.setRequestProperty("Range", "bytes=" + start + "-" + (start + CHUNK_SIZE - 1));
-            currentStart += conn.getContentLengthLong();
+            conn.setRequestProperty("Range", String.format("bytes=%d-", start));
             return conn.getInputStream();
         } catch (IOException e) {
             NetMusic.LOGGER.error("Failed to open audio chunk at {}: {}", start, e.getMessage());
@@ -69,7 +67,7 @@ public class ChunkedAudioStream extends InputStream {
         }
         int bytesRead = currentStream.read(b, off, len);
         if (bytesRead == -1) {
-            // 到达当前流结尾，打开下一个片段
+            // 尝试重新连接
             currentStream.close();
             currentStream = openChunk(currentStart);
             if (currentStream == null) {
@@ -77,6 +75,7 @@ public class ChunkedAudioStream extends InputStream {
             }
             bytesRead = currentStream.read(b, off, len);
         }
+        currentStart += bytesRead;
         return bytesRead;
     }
 


### PR DESCRIPTION
`ChunkedAudioStream` 由原来的每 81920 字节打开一个连接改为当前连接断开后再重新建立新连接，减少连接的建立次数