### PR TITLE
修正与精妙背包的兼容问题

### DIFF
--- a/src/main/java/com/github/tartaricacid/netmusic/compat/sbackpack/NetMusicDiscHandler.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/compat/sbackpack/NetMusicDiscHandler.java
@@ -5,6 +5,7 @@ import com.github.tartaricacid.netmusic.config.GeneralConfig;
 import com.github.tartaricacid.netmusic.config.MusicListManage;
 import com.github.tartaricacid.netmusic.init.InitItems;
 import com.github.tartaricacid.netmusic.item.ItemMusicCD;
+import com.github.tartaricacid.netmusic.network.NetworkHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
@@ -12,7 +13,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 import net.p3pp3rf1y.sophisticatedcore.api.IDiscHandler;
-import net.p3pp3rf1y.sophisticatedcore.network.PacketHandler;
 import net.p3pp3rf1y.sophisticatedcore.upgrades.jukebox.ServerStorageSoundHandler;
 
 import java.util.List;
@@ -35,7 +35,7 @@ public class NetMusicDiscHandler implements IDiscHandler<ItemMusicCD.SongInfo> {
             ItemMusicCD.SongInfo copy = songInfo.clone();
             MusicPlayResolverManager.resolve(copy).thenAcceptAsync(resolved -> {
                 PlayNetMusicDiscMessage message = new PlayNetMusicDiscMessage(storageUuid, resolved, songInfo.songUrl, position);
-                PacketHandler.INSTANCE.sendToAllNear(serverLevel.dimension(), pos, 128, message);
+                NetworkHandler.sendToNearby(serverLevel, pos, 128, message);
             }, serverLevel.getServer());
         });
     }
@@ -49,7 +49,7 @@ public class NetMusicDiscHandler implements IDiscHandler<ItemMusicCD.SongInfo> {
             ItemMusicCD.SongInfo copy = songInfo.clone();
             MusicPlayResolverManager.resolve(copy).thenAcceptAsync(resolved -> {
                 PlayNetMusicDiscMessage message = new PlayNetMusicDiscMessage(storageUuid, resolved, songInfo.songUrl, entityId);
-                PacketHandler.INSTANCE.sendToAllNear(serverLevel.dimension(), position, 128, message);
+                NetworkHandler.sendToNearby(serverLevel, position, 128, message);
             }, serverLevel.getServer());
         });
     }

--- a/src/main/java/com/github/tartaricacid/netmusic/compat/sbackpack/SBackpackCompat.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/compat/sbackpack/SBackpackCompat.java
@@ -2,15 +2,27 @@ package com.github.tartaricacid.netmusic.compat.sbackpack;
 
 import com.github.tartaricacid.netmusic.init.CompatRegistry;
 import net.minecraftforge.fml.ModList;
+import net.minecraftforge.network.simple.SimpleChannel;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 
 public class SBackpackCompat {
+    @SuppressWarnings("Convert2MethodRef")
     public static void register() {
-        ModList.get().getModContainerById(CompatRegistry.SC).ifPresent(modContainer -> {
-            ArtifactVersion version = modContainer.getModInfo().getVersion();
-            if (CompatRegistry.SC_VERSION_RANGE.containsVersion(version)) {
-                SBackpackCompatInner.register();
-            }
-        });
+        checkSBackpackLoad(() -> SBackpackCompatInner.register());
+    }
+
+    public static void initNetwork(SimpleChannel channel) {
+        checkSBackpackLoad(() -> SBackpackCompatInner.initNetwork(channel));
+    }
+
+    public static void checkSBackpackLoad(Runnable runnable) {
+        if (ModList.get().isLoaded(CompatRegistry.SC)) {
+            ModList.get().getModContainerById(CompatRegistry.SC).ifPresent(modContainer -> {
+                ArtifactVersion version = modContainer.getModInfo().getVersion();
+                if (CompatRegistry.SC_VERSION_RANGE.containsVersion(version)) {
+                    runnable.run();
+                }
+            });
+        }
     }
 }

--- a/src/main/java/com/github/tartaricacid/netmusic/compat/sbackpack/SBackpackCompatInner.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/compat/sbackpack/SBackpackCompatInner.java
@@ -1,17 +1,20 @@
 package com.github.tartaricacid.netmusic.compat.sbackpack;
 
-import net.p3pp3rf1y.sophisticatedcore.network.PacketHandler;
+import net.minecraftforge.network.NetworkDirection;
+import net.minecraftforge.network.simple.SimpleChannel;
 import net.p3pp3rf1y.sophisticatedcore.upgrades.jukebox.DiscHandlerRegistry;
+
+import java.util.Optional;
 
 public class SBackpackCompatInner {
     static void register() {
-        // 注册网络包
-        PacketHandler.INSTANCE.registerMessage(
-                PlayNetMusicDiscMessage.class, PlayNetMusicDiscMessage::encode,
-                PlayNetMusicDiscMessage::decode, PlayNetMusicDiscMessage::handle
-        );
-
         // 注册唱片处理器
         DiscHandlerRegistry.registerHandler(new NetMusicDiscHandler());
+    }
+
+    static void initNetwork(SimpleChannel channel) {
+        // 注册网络包
+        channel.registerMessage(101, PlayNetMusicDiscMessage.class, PlayNetMusicDiscMessage::encode, PlayNetMusicDiscMessage::decode, PlayNetMusicDiscMessage::handle,
+                Optional.of(NetworkDirection.PLAY_TO_CLIENT));
     }
 }

--- a/src/main/java/com/github/tartaricacid/netmusic/network/NetworkHandler.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/network/NetworkHandler.java
@@ -1,6 +1,7 @@
 package com.github.tartaricacid.netmusic.network;
 
 import com.github.tartaricacid.netmusic.NetMusic;
+import com.github.tartaricacid.netmusic.compat.sbackpack.SBackpackCompat;
 import com.github.tartaricacid.netmusic.compat.tlm.init.CompatRegistry;
 import com.github.tartaricacid.netmusic.network.message.*;
 import net.minecraft.core.BlockPos;
@@ -9,6 +10,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.network.NetworkDirection;
 import net.minecraftforge.network.NetworkRegistry;
 import net.minecraftforge.network.PacketDistributor;
@@ -36,6 +38,7 @@ public class NetworkHandler {
         CHANNEL.registerMessage(5, BigMegaphoneControlMessage.class, BigMegaphoneControlMessage::encode, BigMegaphoneControlMessage::decode, BigMegaphoneControlMessage::handle,
                 Optional.of(NetworkDirection.PLAY_TO_SERVER));
         CompatRegistry.initNetwork(CHANNEL);
+        SBackpackCompat.initNetwork(CHANNEL);
     }
 
     public static void sendToNearby(Level world, BlockPos pos, Object toSend) {
@@ -50,5 +53,12 @@ public class NetworkHandler {
 
     public static void sendToClientPlayer(Object message, ServerPlayer player) {
         CHANNEL.send(PacketDistributor.PLAYER.with(() -> player), message);
+    }
+
+    public static void sendToNearby(Level world, Vec3 pos, int range, Object toSend) {
+        if (world instanceof ServerLevel) {
+            NetworkHandler.CHANNEL.send(PacketDistributor.NEAR.with(() ->
+                    new PacketDistributor.TargetPoint(pos.x, pos.y, pos.z, range, world.dimension())), toSend);
+        }
     }
 }


### PR DESCRIPTION
在 1.20.1 新版本精妙核心中，`PacketHandler` 的实例化需要从 `SophisticatedCore` 类中获取模组版本，但由于模组加载是并行的，网络音乐机可能在 `SophisticatedCore` 类初始化模组版本前获取模组版本，导致注册网络包时抛出 NPE.