### PR TITLE
修正歌词时间解析问题

### DIFF
--- a/src/main/java/com/github/tartaricacid/netmusic/api/lyric/LyricParser.java
+++ b/src/main/java/com/github/tartaricacid/netmusic/api/lyric/LyricParser.java
@@ -68,10 +68,9 @@ public class LyricParser {
             Matcher matcher = LRC_PATTERN.matcher(line.trim());
             if (matcher.find()) {
                 int minutes = Integer.parseInt(matcher.group(1));
-                int seconds = Integer.parseInt(matcher.group(2));
-                int milliseconds = Integer.parseInt(matcher.group(3));
+                double seconds = Double.parseDouble(matcher.group(2) + "." + matcher.group(3));
                 String text = matcher.group(4).trim();
-                int totalTick = ((minutes * 60 + seconds) * 1000 + milliseconds) / 50;
+                int totalTick = (int) ((minutes * 60 + seconds) * 1000) / 50;
                 lyrics.put(totalTick, text);
             }
         }


### PR DESCRIPTION
歌词时间中的第三项不能简单的解析为毫秒，如 `[00:01.05]` 应该被解析为 1050 (1.05 × 1000) 毫秒而不是 1005 (1000 + 5) 毫秒